### PR TITLE
Fix lost wake-ups in AtomicQueue and UsbBuffer notifications

### DIFF
--- a/src/protocol/usb_buffer.cpp
+++ b/src/protocol/usb_buffer.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 
 DataSlot::DataSlot()
-    : ready(false), offset(0), length(0), size(0), data(nullptr), _cv(nullptr)
+    : ready(false), offset(0), length(0), size(0), data(nullptr), _cv(nullptr), _mtx(nullptr)
 {
 }
 
@@ -19,7 +19,7 @@ DataSlot::~DataSlot()
     }
 }
 
-void DataSlot::init(uint32_t slotSize, std::condition_variable *condition)
+void DataSlot::init(uint32_t slotSize, std::condition_variable *condition, std::mutex *mutex)
 {
     ready.store(false);
     offset = 0;
@@ -27,6 +27,7 @@ void DataSlot::init(uint32_t slotSize, std::condition_variable *condition)
     size = slotSize;
     data = static_cast<uint8_t *>(malloc(size));
     _cv = condition;
+    _mtx = mutex;
 }
 
 void DataSlot::reset()
@@ -43,7 +44,15 @@ void DataSlot::commit(size_t dataSize)
     ready.store(true);
 
     if (_cv)
+    {
+        // Empty critical section orders this wake-up against the reader's
+        // predicate evaluation in UsbBuffer::read, preventing lost wake-ups.
+        if (_mtx)
+        {
+            std::lock_guard<std::mutex> guard(*_mtx);
+        }
         _cv->notify_one();
+    }
 }
 
 bool DataSlot::consume(size_t dataSize)
@@ -70,7 +79,7 @@ UsbBuffer::UsbBuffer(uint16_t slotCount, uint32_t slotSize)
 
     for (uint16_t i = 0; i < _size; i++)
     {
-        _slots[i].init(slotSize, &_cv);
+        _slots[i].init(slotSize, &_cv, &_mutex);
     }
 }
 
@@ -152,6 +161,8 @@ void UsbBuffer::reset()
 
 void UsbBuffer::notify()
 {
+    // See DataSlot::commit - pairs the wake-up with read()'s predicate check.
+    { std::lock_guard<std::mutex> guard(_mutex); }
     _cv.notify_all();
 }
 

--- a/src/protocol/usb_buffer.h
+++ b/src/protocol/usb_buffer.h
@@ -13,7 +13,7 @@ public:
     DataSlot();
     ~DataSlot();
 
-    void init(uint32_t slotSize, std::condition_variable *condition);
+    void init(uint32_t slotSize, std::condition_variable *condition, std::mutex *mutex);
     void reset();
     void commit(size_t dataSize);
     bool consume(size_t dataSize);
@@ -27,6 +27,7 @@ public:
 
 private:
     std::condition_variable *_cv;
+    std::mutex *_mtx;
 };
 
 class UsbBuffer

--- a/src/struct/atomic_queue.h
+++ b/src/struct/atomic_queue.h
@@ -32,7 +32,7 @@ public:
         _first = (_first + 1) % _size;
         _data[_first] = std::move(obj);
         _count.fetch_add(1, std::memory_order_release);
-        _lock.notify_one();
+        wake();
         return true;
     }
 
@@ -47,7 +47,7 @@ public:
         _first = (_first + 1) % _size;
         _data[_first] = std::move(obj);
         _count.fetch_add(1, std::memory_order_release);
-        _lock.notify_one();
+        wake();
         return true;
     }
 
@@ -101,12 +101,23 @@ public:
 
     void notify()
     {
+        // Lock/unlock pairs this notify with any waiter's predicate check,
+        // closing the missed-wakeup window (waiter between predicate and block).
+        { lock_guard<std::mutex> guard(_mtx); }
         _lock.notify_all();
     }
 
     uint16_t count() const { return _count.load(std::memory_order_acquire); }
 
 private:
+    void wake()
+    {
+        // See notify(): empty critical section orders this wake-up against
+        // the waiter's predicate evaluation, preventing lost wake-ups.
+        { lock_guard<std::mutex> guard(_mtx); }
+        _lock.notify_one();
+    }
+
     uint16_t _size;
     unique_ptr<unique_ptr<T>[]> _data;
     uint16_t _first;


### PR DESCRIPTION
## Bug

Producers notify their condition variables without ever synchronizing with the mutex the waiters use:

- `AtomicQueue::pushDiscard` / `pushReplace` / `notify` call `_lock.notify_one()` / `notify_all()` without touching `_mtx`, while `wait()` / `waitFor()` evaluate their predicate under `_mtx`.
- `DataSlot::commit` calls `_cv->notify_one()` (and `UsbBuffer::notify` calls `_cv.notify_all()`) without touching `UsbBuffer::_mutex`, while `UsbBuffer::read` evaluates its predicate under that mutex.

This leaves the classic lost-wake-up window: a consumer holding the mutex evaluates the predicate (sees "empty"), and before it atomically blocks on the condition variable, the producer stores the data and fires the notification. The notify hits no waiter, the consumer then blocks, and the queued data sits there until the next event arrives.

## Symptom

Found while porting to a Raspberry Pi Zero W (single-core ARMv6) head unit: the video/decoder pipeline intermittently stalls — frames are queued but the consumer thread sleeps in `wait()` / `read()` until some later push happens to wake it. On a single core the preemption pattern makes the race easy to hit; on desktop-class machines it is rare but still possible.

## Fix

Take and release the waiters' mutex as an empty critical section immediately before notifying, which orders the notification after the waiter's predicate check (either the waiter sees the new state, or it is already blocked and receives the notify):

- `AtomicQueue`: new private `wake()` helper (lock/unlock `_mtx`, then `notify_one()`) used by both push overloads; `notify()` does the same before `notify_all()`.
- `UsbBuffer`: `DataSlot::init` now also receives a `std::mutex *`; `DataSlot::commit` locks it before `_cv->notify_one()`, and `UsbBuffer::notify` locks `_mutex` before `_cv.notify_all()`.

No behavior change on the fast paths beyond the brief uncontended lock/unlock next to each notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)