### PR TITLE
Fix data race on connection phone name and method strings

### DIFF
--- a/src/protocol/connection.cpp
+++ b/src/protocol/connection.cpp
@@ -314,6 +314,7 @@ void Connection::onPhoneDisconnect()
     if (Settings::onDisconnect.value.length() > 1)
         execute(Settings::onDisconnect.value.c_str());
 
+    std::lock_guard<std::mutex> lock(_nameMutex);
     _method = "unknown";
     _phoneName = "phone";
 }
@@ -639,9 +640,15 @@ void Connection::onMessage(std::unique_ptr<Message> message)
         char buf[64];
         log_d("Controll message %d [%d] > %s", message->type(), message->length(), ascii(message->data(), message->length()).c_str());
         if (jsonFindString(message->data(), message->length(), "MDLinkType", buf, 64))
+        {
+            std::lock_guard<std::mutex> lock(_nameMutex);
             _method = buf;
+        }
         if (jsonFindString(message->data(), message->length(), "btName", buf, 64))
+        {
+            std::lock_guard<std::mutex> lock(_nameMutex);
             _phoneName = buf;
+        }
         return;
     }
 
@@ -659,8 +666,12 @@ const std::string Connection::status() const
         << static_cast<int>(version->micro) << '.'
         << static_cast<int>(version->nano) << " "
         << " queue " << _processQueue.count() << " / " << Settings::usbBuffer << " "
-        << (_ecnrypt.load(std::memory_order_acquire) ? "encrypt" : "simple") << " "
-        << _phoneName << " via " << _method;
+        << (_ecnrypt.load(std::memory_order_acquire) ? "encrypt" : "simple") << " ";
+
+    {
+        std::lock_guard<std::mutex> lock(_nameMutex);
+        out << _phoneName << " via " << _method;
+    }
 
     return out.str();
 }

--- a/src/protocol/connection.h
+++ b/src/protocol/connection.h
@@ -4,6 +4,7 @@
 #include <libusb-1.0/libusb.h>
 
 #include <atomic>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -39,8 +40,19 @@ public:
     uint32_t transfered() const { return _transfered.load(std::memory_order_acquire); }
 
     int8_t state() const { return _state.load(); }
-    std::string connectionMethod() const { return _method; }
-    std::string phoneName() const { return _phoneName; }
+    // _method/_phoneName are reassigned by the process thread while other
+    // threads copy them; copying a std::string during reassignment is a
+    // use-after-free, so every access goes through _nameMutex.
+    std::string connectionMethod() const
+    {
+        std::lock_guard<std::mutex> lock(_nameMutex);
+        return _method;
+    }
+    std::string phoneName() const
+    {
+        std::lock_guard<std::mutex> lock(_nameMutex);
+        return _phoneName;
+    }
     const std::string status() const;
 
     AtomicQueue<Message> writeQueue;
@@ -88,6 +100,7 @@ private:
     std::atomic<bool> _ecnrypt;
     std::atomic<int8_t> _state;
 
+    mutable std::mutex _nameMutex; // guards _method and _phoneName
     std::string _method;
     std::string _phoneName;
     std::atomic<uint32_t> _transfered;


### PR DESCRIPTION
## The bug

`Connection::_phoneName` and `Connection::_method` are plain `std::string` members shared between threads with no synchronization:

- the protocol **process thread** reassigns them when the box settings JSON (`CMD_JSON_CONTROL` with `MDLinkType` / `btName`) arrives, and resets them to `"unknown"` / `"phone"` in `onPhoneDisconnect()`;
- other threads concurrently **copy** them through `phoneName()`, `connectionMethod()`, and `status()`.

A `std::string` reassignment frees the old heap buffer, so a reader copying the string at that moment reads freed memory — a classic use-after-free data race.

## Symptom

Intermittent crashes right around phone (re)connect, exactly when the settings JSON lands while the UI is polling the name/status. It surfaced reliably while porting FastCarPlay to a Raspberry Pi Zero W (ARMv6, single core) head unit, where the tighter thread interleaving on connect made the window easy to hit.

## The fix

Add a `mutable std::mutex _nameMutex` guarding every access to the two strings: the accessors return copies under the lock, the JSON-parse writes and the disconnect reset take the lock, and `status()` reads under it. The lock is only touched on connect/disconnect events and status queries, so it is not on any hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)