### PR TITLE
Fix data race between Decoder::flush() and the decoding thread

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -9,6 +9,7 @@ Decoder::Decoder()
     : buffer(Settings::renderingBuffer),
       _context(nullptr),
       _active(false),
+      _flushRequest(false),
       _data(nullptr)
 {
 }
@@ -42,8 +43,12 @@ void Decoder::stop()
 
 void Decoder::flush()
 {
-    if (_context)
-        avcodec_flush_buffers(_context);
+    // libav contexts are not thread safe: the decoder thread may be inside
+    // avcodec_send_packet/avcodec_receive_frame on the same context, so only
+    // request the flush here and let the decoding loop perform it.
+    _flushRequest.store(true, std::memory_order_release);
+    if (_data)
+        _data->notify();
 }
 
 // Initialize and select the best decoder (try HW first, then SW)
@@ -170,6 +175,10 @@ void Decoder::loop(AVCodecContext *context, AVCodecParserContext *parser, AVPack
     // Main decoding loop; runs until global_quit flag is set
     while (_data->wait(_active))
     {
+        // Perform a requested flush here, on the thread that owns the context
+        if (_flushRequest.exchange(false, std::memory_order_acq_rel))
+            avcodec_flush_buffers(context);
+
         // Get raw data segment from queue
         std::unique_ptr<Message> segment = _data->pop();
         uint8_t *data_ptr = segment->data();

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -35,6 +35,7 @@ private:
     AVCodecContext* _context;
     AVCodecID _codecId;
     std::atomic<bool> _active;
+    std::atomic<bool> _flushRequest;
     AtomicQueue<Message> *_data;
 };
 


### PR DESCRIPTION
## Bug

`Decoder::flush()` runs on the caller's thread and calls `avcodec_flush_buffers(_context)` directly, while the decoder thread may be inside `avcodec_send_packet()` / `avcodec_receive_frame()` on the same context. libav codec contexts are not thread safe, so the two calls race on the decoder's internal state.

## Symptom

Intermittent corrupted frames or crashes inside the decoder when a flush arrives during active decoding. Found while porting FastCarPlay to a Raspberry Pi Zero W (ARMv6) head unit, where the slow single core keeps the decoder thread inside libav long enough to hit the race regularly.

## Fix

`flush()` no longer touches the context. It only sets a new `std::atomic<bool> _flushRequest` flag (release store) and wakes the data queue. The decoding loop consumes the flag at the top of its outer loop (`exchange`, acq_rel) and calls `avcodec_flush_buffers()` there — on the thread that owns the context, between decode calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)