### PR TITLE
Fix unaligned wide loads in PcmAudio::isZero

### DIFF
--- a/src/pcm_audio.cpp
+++ b/src/pcm_audio.cpp
@@ -72,11 +72,26 @@ ChannelConfig PcmAudio::getConfig(const Message *msg)
 
 bool PcmAudio::isZero(const Message *msg)
 {
-    const uint64_t *p = (const uint64_t *)msg->data();
-    int n = msg->length() / 8;
-    for (int i = 0; i < n; ++i)
+    // The payload offset gives no alignment guarantee and unaligned wide
+    // loads fault on ARMv6, so align to 4 bytes before scanning by word.
+    const uint8_t *p = msg->data();
+    int n = msg->length();
+    while (n > 0 && ((uintptr_t)p & 3))
     {
-        if (p[i] != 0)
+        if (*p++)
+            return false;
+        --n;
+    }
+    const uint32_t *w = (const uint32_t *)p;
+    for (; n >= 4; n -= 4)
+    {
+        if (*w++)
+            return false;
+    }
+    p = (const uint8_t *)w;
+    for (; n > 0; --n)
+    {
+        if (*p++)
             return false;
     }
     return true;


### PR DESCRIPTION
## Bug

`PcmAudio::isZero` casts the message payload pointer straight to `const uint64_t *` and scans it with 64-bit loads. `Message::data()` returns the buffer at a protocol payload offset, so the pointer has no alignment guarantee. Dereferencing an unaligned `uint64_t *` is undefined behavior; it only happens to work on x86, where the hardware tolerates unaligned access.

## Symptom

Found while porting FastCarPlay to a Raspberry Pi Zero W (ARM11 / ARMv6) head unit: the ARM11 core does not support unaligned doubleword loads (`ldrd`/`ldm`), so the silence check crashes with a bus error / SIGBUS as soon as audio segments arrive. The trailing `length % 8` bytes were also never checked.

## Fix

Scan in three stages: a byte loop until the pointer reaches 4-byte alignment, an aligned `uint32_t` loop for the bulk, and a byte loop for the tail. Same result on all platforms, no unaligned accesses, and the tail bytes are now included in the check. Function signature and call sites are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)