### PR TITLE
Run custom key scripts without blocking the render loop

### DIFF
--- a/src/common/functions.h
+++ b/src/common/functions.h
@@ -1,11 +1,15 @@
 #ifndef SRC_COMMON_FUNCTIONS
 #define SRC_COMMON_FUNCTIONS
 
+#include <cerrno>
+#include <csignal>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <SDL2/SDL.h>
 
@@ -23,7 +27,25 @@ inline void execute(const char *path)
         throw std::invalid_argument("Program path cannot be empty");
     }
 
-    std::system(path);
+    // Detached double-fork: never blocks the calling thread, no zombies
+    // (std::system would stall the render loop until the script exits).
+    pid_t pid = fork();
+    if (pid < 0)
+        return;
+    if (pid == 0)
+    {
+        if (fork() == 0)
+        {
+            setsid();
+            signal(SIGPIPE, SIG_DFL); // don't leak the app's SIG_IGN into user scripts
+            execl("/bin/sh", "sh", "-c", path, (char *)nullptr);
+            _exit(127);
+        }
+        _exit(0);
+    }
+    while (waitpid(pid, nullptr, 0) < 0 && errno == EINTR)
+    {
+    }
 }
 
 inline const std::string avErrorText(int code)


### PR DESCRIPTION
## Bug

`execute()` in `src/common/functions.h` runs custom key scripts with `std::system()`, which waits synchronously for the command to finish. Since it is called from the main/render thread, the UI and video stream freeze for as long as the script runs. The child also inherits the app's signal dispositions (e.g. an ignored `SIGPIPE`), which can change how user scripts behave.

Found while porting to a Raspberry Pi Zero W (ARMv6) head unit, where even short shell scripts are slow enough to make the freeze very visible.

## Fix

Replace `std::system()` with a detached double-fork:

- fork; the child forks again and `_exit(0)`s immediately
- the grandchild calls `setsid()`, restores `SIGPIPE` to `SIG_DFL`, and `execl`s `/bin/sh -c <path>`
- the parent `waitpid()`s only the short-lived intermediate child (with an `EINTR` retry loop)

The render loop never waits on the script, and because the grandchild is reparented to init, no zombie processes are left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)