### PR TITLE
Handle SIGTERM/SIGINT for clean shutdown

### DIFF
--- a/src/application.h
+++ b/src/application.h
@@ -1,6 +1,8 @@
 #ifndef SRC_APPLICATION
 #define SRC_APPLICATION
 
+#include <atomic>
+
 #include <SDL2/SDL.h>
 
 #include "protocol/protocol_const.h"
@@ -18,6 +20,9 @@ public:
     ~Application();
 
     void start(const char *title);
+
+    // Requests a clean shutdown; safe to call from a signal handler
+    void stop() { _active.store(false, std::memory_order_release); }
 
 private:
     struct State
@@ -43,7 +48,7 @@ private:
     SDL_Window *_window;
     SDL_Renderer *_renderer;
     PipeListener *_keyListener;
-    bool _active;
+    std::atomic<bool> _active;
     SDL_DisplayMode _displayMode;
     State _state;
     int _width;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include <string>
 #include <iostream>
 #include <memory>
+#include <atomic>
+#include <csignal>
 
 #include "common/functions.h"
 #include "common/logger.h"
@@ -10,12 +12,40 @@
 
 static const char *title = "Fast Car Play v0.9";
 
+static std::atomic<Application *> g_app{nullptr};
+
+static void onStopSignal(int)
+{
+    // async-signal-safe: lock-free atomic load + atomic store only
+    Application *app = g_app.load(std::memory_order_acquire);
+    if (app)
+        app->stop();
+}
+
+static void installSignalHandlers()
+{
+    struct sigaction sa = {};
+    sa.sa_handler = onStopSignal;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGTERM, &sa, nullptr);
+    sigaction(SIGINT, &sa, nullptr);
+    signal(SIGPIPE, SIG_IGN);
+}
+
 void start()
 {
     set_log_level(Settings::loglevel);
     Settings::print();
 
     Application app;
+    // Guard declared after app: it resets g_app BEFORE app is destroyed,
+    // including on the exception paths out of app.start()
+    struct Guard
+    {
+        ~Guard() { g_app.store(nullptr, std::memory_order_release); }
+    } guard;
+    g_app.store(&app, std::memory_order_release);
+    installSignalHandlers();
     app.start(title);
 }
 


### PR DESCRIPTION
## Bug

The app installs no signal handlers, so SIGTERM and SIGINT terminate the process immediately with the default action. `Application`, `Connection`, `Decoder` and the audio objects never run their destructors: worker threads are killed mid-flight and the USB interface is never released.

Found while porting FastCarPlay to a Raspberry Pi Zero W head unit, where the app runs as a systemd service: every `systemctl stop` (including system shutdown) delivers SIGTERM, killing the process without releasing the dongle. Ctrl-C during interactive runs has the same effect.

## Fix

- `Application::stop()` — a public method that only performs an atomic store, so it is safe to call from a signal handler; `_active` becomes `std::atomic<bool>` (the main loop already checks it every iteration, no other change needed).
- `main.cpp` installs `sigaction` handlers for SIGTERM/SIGINT that load a static `std::atomic<Application *>` and call `stop()`, so the main loop exits normally and everything unwinds through the existing destructors.
- SIGPIPE is ignored so a broken pipe (e.g. the key pipe reader going away) can't kill the process either.
- A scope guard declared after the `Application` clears the global pointer before the object is destroyed, covering exception paths too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)