### PR TITLE
Add header dependency tracking to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,15 @@ $(TARGET): $(OBJS)
 	$(CXX) $(LDFLAGS) $(OBJS) -o $(TARGET) $(LDOPTIONS)
 	@echo "Build complete: $(TARGET)"
 
+# -MMD writes a .d file per object listing every header it includes, and the
+# -include below feeds them back in, so editing a header rebuilds its users.
+# Without this, objects built against an old header layout get linked next to
+# fresh ones and corrupt memory at runtime.
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
 	@mkdir -p $(dir $@)
-	$(CXX) $(CXXCOMMON) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CXXCOMMON) $(CXXFLAGS) -MMD -MP -c $< -o $@
+
+-include $(OBJS:.o=.d)
 
 clean:
 	@rm -rf $(OUT_DIR)


### PR DESCRIPTION
## Bug

The object pattern rule compiles without generating dependency files, so make only knows that each `.o` depends on its `.cpp`. Editing a header rebuilds nothing that includes it.

## Symptom

After changing a class layout in a header (e.g. adding a member), an incremental build links stale objects compiled against the old layout together with fresh ones using the new layout. The result is silent memory corruption at runtime — we hit it as "stack smashing detected" and random segfaults while porting FastCarPlay to a Raspberry Pi Zero W (ARMv6) head unit, and it was very hard to trace back to the build system. `make clean` "fixes" it, which is the tell.

## Fix

Compile with `-MMD -MP` so the compiler emits a `.d` makefile per object listing every header it includes, and `-include $(OBJS:.o=.d)` to feed those back into make. Touching a header now rebuilds exactly the objects that include it. First builds are unaffected; the `.d` files live in the existing per-build-type object tree and are removed by `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)